### PR TITLE
feat: adiciona exemplo de upload com Quick framework

### DIFF
--- a/quick/example.upload/.gitignore
+++ b/quick/example.upload/.gitignore
@@ -1,0 +1,17 @@
+# Binários
+upload-server
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Diretório de uploads
+uploads/
+
+# Arquivos de teste
+test_image.png
+*.test
+
+# Arquivos do sistema
+.DS_Store
+Thumbs.db

--- a/quick/example.upload/README.md
+++ b/quick/example.upload/README.md
@@ -1,0 +1,172 @@
+# Example Upload - Quick Framework
+
+Este exemplo demonstra como criar um servidor de upload de imagens usando o framework [Quick](https://github.com/jeffotoni/quick) do jeffotoni.
+
+## Descrição
+
+API simples para upload de avatar de usuário que:
+- Recebe imagens através do endpoint `/v1/user/avatar`
+- Suporta dois métodos: JSON com base64 e multipart/form-data
+- Valida o formato do arquivo (jpg, jpeg, png, gif, webp, bmp)
+- Salva a imagem no diretório `uploads/`
+- Retorna JSON com confirmação e informações do arquivo
+
+## Como executar
+
+```bash
+# Entre no diretório
+cd example.upload
+
+# Execute o servidor
+go run main.go
+```
+
+O servidor estará rodando em `http://localhost:8080`
+
+## Como testar
+
+### Método 1: JSON com Base64 (Recomendado)
+
+Este é o método recomendado para usar com o framework Quick:
+
+```bash
+# Primeiro, codifique sua imagem em base64
+BASE64_IMG=$(base64 -w 0 sua_imagem.png)
+
+# Faça o upload
+curl -X POST http://localhost:8080/v1/user/avatar \
+  -H "Content-Type: application/json" \
+  -d "{\"filename\":\"avatar.png\",\"content\":\"$BASE64_IMG\"}"
+```
+
+### Método 2: Multipart Form Data (Alternativo)
+
+```bash
+# Upload usando multipart (endpoint alternativo)
+curl -X POST http://localhost:8080/v1/user/avatar/multipart \
+  -F "avatar=@sua_imagem.png"
+```
+
+**Nota**: O endpoint multipart pode ter limitações devido ao funcionamento interno do Quick framework.
+
+### Resposta de sucesso
+
+```json
+{
+  "success": true,
+  "message": "Avatar salvo com sucesso!",
+  "filename": "avatar_1234567890.png",
+  "size": 245678,
+  "path": "uploads/avatar_1234567890.png",
+  "uploaded_at": "2025-10-23T10:30:45Z",
+  "original_name": "avatar.png"
+}
+```
+
+### Resposta de erro
+
+```json
+{
+  "success": false,
+  "message": "Campos 'filename' e 'content' são obrigatórios"
+}
+```
+
+## Endpoints
+
+### POST /v1/user/avatar
+Upload de imagem usando JSON com base64
+
+**Request:**
+```json
+{
+  "filename": "avatar.png",
+  "content": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ..."
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Avatar salvo com sucesso!",
+  "filename": "avatar_1761227642.png",
+  "size": 67,
+  "path": "uploads/avatar_1761227642.png",
+  "uploaded_at": "2025-10-23T13:54:02Z",
+  "original_name": "avatar.png"
+}
+```
+
+### POST /v1/user/avatar/multipart
+Upload de imagem usando multipart/form-data (alternativo)
+
+**Request:**
+```bash
+curl -F "avatar=@imagem.png" http://localhost:8080/v1/user/avatar/multipart
+```
+
+### GET /
+Página inicial com informações e exemplos de uso
+
+## Formatos suportados
+
+- JPG / JPEG
+- PNG
+- GIF
+- WEBP
+- BMP
+
+## Estrutura do projeto
+
+```
+example.upload/
+├── main.go          # Código principal do servidor
+├── go.mod           # Dependências do projeto
+├── go.sum           # Checksums das dependências
+├── uploads/         # Diretório onde os arquivos são salvos
+└── README.md        # Este arquivo
+```
+
+## Features
+
+- ✅ Upload de imagens via JSON com base64
+- ✅ Upload alternativo via multipart/form-data
+- ✅ Validação de formato
+- ✅ Nome único para cada arquivo (timestamp)
+- ✅ Resposta JSON estruturada
+- ✅ Tratamento de erros
+- ✅ Criação automática do diretório uploads
+- ✅ Dois endpoints para flexibilidade
+
+## Exemplo completo de uso
+
+```bash
+# 1. Inicie o servidor
+go run main.go
+
+# 2. Em outro terminal, faça o upload
+# Método JSON (recomendado):
+curl -X POST http://localhost:8080/v1/user/avatar \
+  -H "Content-Type: application/json" \
+  -d '{"filename":"avatar.png","content":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="}'
+
+# Método multipart (alternativo):
+curl -X POST http://localhost:8080/v1/user/avatar/multipart \
+  -F "avatar=@test_image.png"
+
+# 3. Verifique o arquivo salvo
+ls -l uploads/
+```
+
+## Sobre o Quick Framework
+
+Quick é um framework web minimalista e rápido para Go, criado por [@jeffotoni](https://github.com/jeffotoni). Ele oferece uma API simples e intuitiva para criar aplicações web.
+
+Neste exemplo, demonstramos como lidar com uploads de arquivos usando duas abordagens:
+1. **JSON com base64**: Método mais compatível com o Quick, usando o `BodyParser` nativo
+2. **Multipart**: Método alternativo que pode ter limitações dependendo da versão do Quick
+
+## Licença
+
+MIT

--- a/quick/example.upload/go.mod
+++ b/quick/example.upload/go.mod
@@ -1,0 +1,5 @@
+module example.upload
+
+go 1.20
+
+require github.com/jeffotoni/quick v0.0.0-20230404232930-eda8d6b279e3

--- a/quick/example.upload/go.sum
+++ b/quick/example.upload/go.sum
@@ -1,0 +1,2 @@
+github.com/jeffotoni/quick v0.0.0-20230404232930-eda8d6b279e3 h1:bCa1kLXW0lQAALrHEWrCCFpcQtRrECVF713kf6B7MCI=
+github.com/jeffotoni/quick v0.0.0-20230404232930-eda8d6b279e3/go.mod h1:Q6QgCMmtWvoY1+x45mp/M+S6E+X+swyjknFV6VfT8Qg=

--- a/quick/example.upload/main.go
+++ b/quick/example.upload/main.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jeffotoni/quick"
+)
+
+func main() {
+	app := quick.New()
+
+	// Endpoint para upload de avatar usando base64
+	app.Post("/v1/user/avatar", func(c *quick.Ctx) error {
+		c.Set("Content-Type", "application/json")
+
+		// Estrutura para receber o upload
+		type UploadRequest struct {
+			Filename string `json:"filename"`
+			Content  string `json:"content"` // base64 encoded
+		}
+
+		var req UploadRequest
+		err := c.BodyParser(&req)
+		if err != nil {
+			return c.Status(400).JSON(map[string]interface{}{
+				"success": false,
+				"message": "Erro ao fazer parse do JSON",
+				"error":   err.Error(),
+			})
+		}
+
+		if req.Filename == "" || req.Content == "" {
+			return c.Status(400).JSON(map[string]interface{}{
+				"success": false,
+				"message": "Campos 'filename' e 'content' são obrigatórios",
+			})
+		}
+
+		// Decodifica o base64
+		fileContent, err := base64.StdEncoding.DecodeString(req.Content)
+		if err != nil {
+			return c.Status(400).JSON(map[string]interface{}{
+				"success": false,
+				"message": "Erro ao decodificar base64",
+				"error":   err.Error(),
+			})
+		}
+
+		// Valida extensão
+		ext := strings.ToLower(filepath.Ext(req.Filename))
+		allowedExts := map[string]bool{
+			".jpg": true, ".jpeg": true, ".png": true,
+			".gif": true, ".webp": true, ".bmp": true,
+		}
+
+		if !allowedExts[ext] {
+			return c.Status(400).JSON(map[string]interface{}{
+				"success": false,
+				"message": "Formato não suportado. Use: jpg, jpeg, png, gif, webp, bmp",
+			})
+		}
+
+		// Cria diretório
+		uploadsDir := "./uploads"
+		os.MkdirAll(uploadsDir, 0755)
+
+		// Nome único
+		filename := fmt.Sprintf("avatar_%d%s", time.Now().Unix(), ext)
+		filePath := filepath.Join(uploadsDir, filename)
+
+		// Salva arquivo
+		err = os.WriteFile(filePath, fileContent, 0644)
+		if err != nil {
+			return c.Status(500).JSON(map[string]interface{}{
+				"success": false,
+				"message": "Erro ao salvar arquivo",
+				"error":   err.Error(),
+			})
+		}
+
+		return c.Status(200).JSON(map[string]interface{}{
+			"success":      true,
+			"message":      "Avatar salvo com sucesso!",
+			"filename":     filename,
+			"size":         len(fileContent),
+			"path":         filePath,
+			"uploaded_at":  time.Now().Format(time.RFC3339),
+			"original_name": req.Filename,
+		})
+	})
+
+	// Endpoint alternativo para upload usando multipart (raw HTTP)
+	app.Post("/v1/user/avatar/multipart", func(c *quick.Ctx) error {
+		c.Set("Content-Type", "application/json")
+
+		// Tenta ler o multipart diretamente
+		mr, err := c.Request.MultipartReader()
+		if err != nil {
+			return c.Status(400).JSON(map[string]interface{}{
+				"success": false,
+				"message": "Não foi possível ler multipart form",
+				"error":   err.Error(),
+				"hint":    "Use o endpoint /v1/user/avatar com JSON {\"filename\": \"...\", \"content\": \"base64...\"}",
+			})
+		}
+
+		for {
+			part, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return c.Status(400).JSON(map[string]interface{}{
+					"success": false,
+					"message": "Erro ao ler parte do multipart",
+					"error":   err.Error(),
+				})
+			}
+
+			if part.FormName() == "avatar" && part.FileName() != "" {
+				// Valida extensão
+				ext := strings.ToLower(filepath.Ext(part.FileName()))
+				allowedExts := map[string]bool{
+					".jpg": true, ".jpeg": true, ".png": true,
+					".gif": true, ".webp": true, ".bmp": true,
+				}
+
+				if !allowedExts[ext] {
+					return c.Status(400).JSON(map[string]interface{}{
+						"success": false,
+						"message": "Formato não suportado",
+					})
+				}
+
+				// Cria diretório
+				uploadsDir := "./uploads"
+				os.MkdirAll(uploadsDir, 0755)
+
+				// Nome único
+				filename := fmt.Sprintf("avatar_%d%s", time.Now().Unix(), ext)
+				filePath := filepath.Join(uploadsDir, filename)
+
+				// Salva arquivo
+				dst, err := os.Create(filePath)
+				if err != nil {
+					return c.Status(500).JSON(map[string]interface{}{
+						"success": false,
+						"message": "Erro ao criar arquivo",
+						"error":   err.Error(),
+					})
+				}
+				defer dst.Close()
+
+				size, err := io.Copy(dst, part)
+				if err != nil {
+					return c.Status(500).JSON(map[string]interface{}{
+						"success": false,
+						"message": "Erro ao salvar arquivo",
+						"error":   err.Error(),
+					})
+				}
+
+				return c.Status(200).JSON(map[string]interface{}{
+					"success":     true,
+					"message":     "Avatar salvo com sucesso!",
+					"filename":    filename,
+					"size":        size,
+					"path":        filePath,
+					"uploaded_at": time.Now().Format(time.RFC3339),
+				})
+			}
+		}
+
+		return c.Status(400).JSON(map[string]interface{}{
+			"success": false,
+			"message": "Campo 'avatar' não encontrado",
+		})
+	})
+
+	// Rota de teste
+	app.Get("/", func(c *quick.Ctx) error {
+		return c.Status(200).SendString(`Upload API - Quick Framework
+
+Endpoints:
+- POST /v1/user/avatar (JSON com base64)
+- POST /v1/user/avatar/multipart (multipart/form-data)
+
+Exemplo de uso com JSON:
+curl -X POST http://localhost:8080/v1/user/avatar \
+  -H "Content-Type: application/json" \
+  -d '{"filename":"avatar.png","content":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="}'
+
+Exemplo de uso com multipart:
+curl -X POST http://localhost:8080/v1/user/avatar/multipart \
+  -F "avatar=@imagem.png"`)
+	})
+
+	fmt.Println("🚀 Servidor rodando em http://localhost:8080")
+	fmt.Println("📤 Endpoint principal: POST http://localhost:8080/v1/user/avatar")
+	fmt.Println("📤 Endpoint alternativo: POST http://localhost:8080/v1/user/avatar/multipart")
+	app.Listen(":8080")
+}


### PR DESCRIPTION
Cria exemplo funcional de upload de imagens usando o framework Quick.

Funcionalidades:
- Endpoint /v1/user/avatar para upload via JSON com base64
- Endpoint /v1/user/avatar/multipart para upload multipart (alternativo)
- Validação de formatos de imagem (jpg, jpeg, png, gif, webp, bmp)
- Nome único com timestamp para cada arquivo
- Resposta JSON com informações do upload
- Documentação completa no README

O exemplo demonstra a melhor forma de trabalhar com uploads no Quick, usando JSON com base64 como método principal, já que o framework tem limitações com multipart/form-data devido ao seu processamento interno do body do request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)